### PR TITLE
pipx-in-pipx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,11 @@ But `pipx`_ is a CLI tool installed through ``pip``...why not install `pipx`_ wi
 Why not indeed!
 
 
-With ``pipipxx`` (pronounced "pipx in pipx"), all you need to do is:
+With ``pipipxx`` (pronounced "pipx in pipx"),all you need to do is install :
 
 .. code:: shell
 
-    $ pip install pipipxx
+    $ pip install pipx-in-pipx
 
 But wait! You say.
 Didn't you just say that we shouldn't install things to system Python?

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-#######
-pipipxx
-#######
+############
+pipx-in-pipx
+############
 
 .. image:: https://img.shields.io/pypi/v/pipipxx.svg
    :target: https://pypi.python.org/pypi/pipipxx
@@ -33,7 +33,7 @@ But `pipx`_ is a CLI tool installed through ``pip``...why not install `pipx`_ wi
 Why not indeed!
 
 
-With ``pipipxx`` (pronounced "pipx in pipx"),all you need to do is install :
+With ``pipx-in-pipx``, all you need to do is install :
 
 .. code:: shell
 
@@ -43,9 +43,9 @@ But wait! You say.
 Didn't you just say that we shouldn't install things to system Python?
 
 Yes.
-What ``pipipxx`` actually does is slightly (but only slightly) evil.
+What ``pipx-in-pipx`` actually does is slightly (but only slightly) evil.
 Rather than actually installing anything when you run "install",
-``pipipxx`` instead builds a temporary virtual environment,
+``pipx-in-pipx`` instead builds a temporary virtual environment,
 installs `pipx`_ there,
 and then uses *that* `pipx`_ to install `pipx`_ in your user local space,
 just like any other `pipx`_-installed tool.
@@ -61,9 +61,9 @@ Which Python?
 
 By default, `pipx`_ uses its own Python for each environment that it creates.
 Normally, this would be the system Python, whatever it was when you installed `pipx`_.
-However, when your are using a ``pipipxx``-installed `pipx`_,
+However, when your are using a ``pipx-in-pipx``-installed `pipx`_,
 the default Python that `pipx`_ uses for each environment it creates is instead
-whatever Python you used to "install" ``pipipxx``.
+whatever Python you used to "install" ``pipx-in-pipx``.
 
 This has two notable side effects:
 
@@ -82,12 +82,12 @@ Because you have now made `pipx`_ manage itself,
 running ``pipx uninstall-all`` *will also* uninstall `pipx`_.
 
 This is not a bug, but a feature.
-By installing `pipx`_ using ``pipipxx``,
+By installing `pipx`_ using ``pipx-in-pipx``,
 you have expressed an intent that you *want* `pipx`_ to manage itself.
 If that's not what you want, this is not the tool for you.
 
 If you at any point uninstall your `pipx`_-managed `pipx`_,
-you can simply ``pip install pipipxx`` again to rebuild it.
+you can simply ``pip install pipx-in-pipx`` again to rebuild it.
 
 
 .. _pipx: https://pipxproject.github.io/pipx/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -29,7 +29,7 @@ def get_version():
     return _release
 
 
-project = u"pipipxx"
+project = u"pipx-in-pipx"
 version = get_version()
 release = get_release()
 

--- a/park.cfg
+++ b/park.cfg
@@ -14,5 +14,4 @@ description_keys:
 
 [names]
 pipxinpipx:
-pipx-in-pipx:
 pipipx:

--- a/park.cfg
+++ b/park.cfg
@@ -1,13 +1,13 @@
 [DEFAULT]
-version: 0.0.1
+version: 0.0.2
 author: Matt Bullock
 author_email: m@ttsb42.com
 url: https://pipipxx.readthedocs.io/en/stable/
-description: Did you mean to install pipipxx?
+description: Did you mean to install pipx-in-pipx?
 long_description:
     This package has been parked by {author} to protect you against packages
     adopting names that might be common mistakes when looking for ours. You probably
-    wanted to install pipipxx. For more information, see {url}.
+    wanted to install pipx-in-pipx. For more information, see {url}.
 description_keys:
     author
     url

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,7 @@ def read(*args: str) -> str:
     return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
 
 
-setup(
-    name="pipipxx",
+setup_kwargs = dict(
     version=__version__,
     url="https://github.com/mattsb42/pipipxx",
     author="Matt Bullock",
@@ -98,3 +97,6 @@ setup(
     ],
     cmdclass=dict(install=BootstrapInstall),
 )
+
+for name in ("pipipxx", "pipx-in-pipx"):
+    setup(name=name, **setup_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def read(*args: str) -> str:
     return io.open(os.path.join(HERE, *args), encoding="utf-8").read()
 
 
-setup_kwargs = dict(
+SETUP_KWARGS = dict(
     version=__version__,
     url="https://github.com/mattsb42/pipipxx",
     author="Matt Bullock",
@@ -99,4 +99,4 @@ setup_kwargs = dict(
 )
 
 for name in ("pipipxx", "pipx-in-pipx"):
-    setup(name=name, **setup_kwargs)
+    setup(name=name, **SETUP_KWARGS)

--- a/tox.ini
+++ b/tox.ini
@@ -167,6 +167,12 @@ commands = python setup.py check -r -s
 
 [testenv:lint]
 basepython = python3
+# This lets this testenv execute all commands,
+#  even if some fail. If *any* fail,
+#  the command still fails,
+#  but this lets us get the failing results
+#  for all commands at once.
+ignore_errors=true
 whitelist_externals = {[testenv:resetdocs]whitelist_externals}
 deps =
     {[testenv:autoformat]deps}


### PR DESCRIPTION
fixes #14 

The `pipipxx` name was supposed to be clever, but it has turned out to just be confusing. :(

In light of this, I'm changing the project name to `pipx-in-pipx`. I will continue to publish all new releases to `pipipxx` as well, so `pip install pipipxx` will still Do The Right Thing.